### PR TITLE
mineを埋めるロジックを別クラス(MinePlanter)に分離してみた

### DIFF
--- a/minesweeper.rb
+++ b/minesweeper.rb
@@ -18,9 +18,11 @@ class Board
 
   private attr_reader :grid, :cells
 
-  def initialize(width: 9, height: 9, mine_count: 10)
-    @cells = make_cells_with_mine(width:, height:, mine_count:)
+  def initialize(width: 9, height: 9, mine_count: 10, planter: MinePlanter::Random.new(mine_count))
+    @cells = Array.new(width * height) { Cell.new }
     @grid = cells.each_slice(width).to_a
+
+    planter.plant_to(cells)
     set_neighbors_mine_count_to_all_of_cells
   end
 
@@ -73,12 +75,6 @@ class Board
   private def width = grid.first.size
   private def height = grid.size
 
-  private def make_cells_with_mine(width:, height:, mine_count:)
-    Array.new(width * height) { Cell.new }.tap do |cells|
-      cells.sample(mine_count).each(&:plant_mine)
-    end
-  end
-
   private def set_neighbors_mine_count_to_all_of_cells
     height.times do |y|
       width.times do |x|
@@ -112,6 +108,21 @@ class Board
       next if [nx, ny].min.negative?
 
       [nx, ny]
+    end
+  end
+end
+
+class MinePlanter
+  class Random < MinePlanter
+    attr_reader :mine_count
+
+    def initialize(mine_count)
+      super()
+      @mine_count = mine_count
+    end
+
+    def plant_to(cells)
+      cells.sample(mine_count).each(&:plant_mine)
     end
   end
 end

--- a/test/board_test.rb
+++ b/test/board_test.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require_relative '../minesweeper'
+
+class MinePlanter
+  class Preset < MinePlanter
+    attr_reader :mine_positions
+
+    def initialize(mine_positions)
+      super()
+      @mine_positions = mine_positions.delete("\n").chars
+    end
+
+    def plant_to(cells)
+      mine_positions.each_with_index do |mark, i|
+        mark == 'x' && cells[i].plant_mine
+      end
+    end
+  end
+end
+
+class BoardTest < Minitest::Test
+  def setup
+    $stdout = File.open('/dev/null', 'w')
+  end
+
+  def teardown
+    $stdout.close
+    $stdout = STDOUT
+  end
+
+  def test_デフォルトのBoard
+    b = Board.new
+    assert_equal 9 + 4, b.show
+    refute b.finished?
+
+    assert_raises(Board::GameOver) do
+      9.times do |x|
+        9.times do |y|
+          b.open(x:, y:)
+        end
+      end
+    end
+  end
+
+  def test_PresetMinePlanterを使ったBoard
+    b = Board.new(planter: MinePlanter::Preset.new(<<~MAP))
+      ---------
+      ---------
+      --x------
+      ---------
+      ---------
+      ---------
+      ------x--
+      ---------
+      ---------
+    MAP
+
+    assert_equal 9 + 4, b.show
+    refute b.finished?
+
+    9.times do |x|
+      9.times do |y|
+        next if [x, y] in [2, 2] | [6, 6]
+        
+        b.open(x:, y:)
+      end
+    end
+
+    assert b.finished?
+  end
+end

--- a/test/mine_planter_random_test.rb
+++ b/test/mine_planter_random_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require_relative '../minesweeper'
+
+class MinePlanter
+  class RandomTest < Minitest::Test
+    def test_initialize
+      assert_raises(ArgumentError) { MinePlanter::Random.new }
+    end
+
+    def test_3個のmineを埋める
+      planter = MinePlanter::Random.new(3)
+
+      cells = Array.new(2) { Cell.new }
+      planter.plant_to(cells)
+      assert_equal 2, cells.count(&:mine?)
+
+      cells = Array.new(3) { Cell.new }
+      planter.plant_to(cells)
+      assert cells.all?(&:mine?)
+
+      cells = Array.new(4) { Cell.new }
+      planter.plant_to(cells)
+      assert_equal 3, cells.count(&:mine?)
+    end
+  end
+end


### PR DESCRIPTION
Board#open のテストを書こうとしたが、BoardがCellを格納している cells と grid のattr_readerはprivateなので外から見えません。

- Board.newした後に本当に9x9でmineが10個埋まってるかをどうテストするの？ とか
- openしようにもmineの場所は毎回変るわけで、どうやってテストするの？まさにゲームじゃん とか

[柏.rb #4](https://kashiwarb.connpass.com/event/333529/) でザックリ聞いたら「mineを埋めるロジックを別クラスにするとかすれば、どこにmineがあるかわかるんじゃない？」
というヒントをもらった。なるほど。

と、いう事で Board.new した時、initializeの中でCellを生成してmineを埋め込むのではなく、
mine を埋めるロジックを持ったplanterを受けられるようにしておいて
Cellは生成するんだけど、mineの埋め込みはそのplanterにplant_to(cells)で埋め込んでもらう形にしてみた。

が、それだけじゃだめでした。

通常ランダムに配置されるmineを、テストでは指定位置に配置する事が可能になったので、mineを当てたり、mineを避けたりするテストは可能になった。

しかし、

- Boardの中のCellがどうなっているかは、あいかわらず外からはわからないので、flagメソッドで旗を立てても本当に立っているかassertできない
- 近隣にmineがない 0 の Cell を open した時に周りも連鎖的(再帰的)に開けたか assert できない

という問題が発生