### PR TITLE
Boardの外でCellのgridを作ってそれをBoard.newに渡す形にしテストを書いた

### DIFF
--- a/minesweeper.rb
+++ b/minesweeper.rb
@@ -18,9 +18,9 @@ class Board
 
   private attr_reader :grid, :cells
 
-  def initialize(width: 9, height: 9, mine_count: 10)
-    @cells = make_cells_with_mine(width:, height:, mine_count:)
-    @grid = cells.each_slice(width).to_a
+  def initialize(grid = Cell.grid_with_mine)
+    @grid = grid
+    @cells = grid.flatten
     set_neighbors_mine_count_to_all_of_cells
   end
 
@@ -72,12 +72,6 @@ class Board
 
   private def width = grid.first.size
   private def height = grid.size
-
-  private def make_cells_with_mine(width:, height:, mine_count:)
-    Array.new(width * height) { Cell.new }.tap do |cells|
-      cells.sample(mine_count).each(&:plant_mine)
-    end
-  end
 
   private def set_neighbors_mine_count_to_all_of_cells
     height.times do |y|
@@ -134,6 +128,12 @@ class Cell
   attr_accessor :neighbors_mine_count
 
   private attr_accessor :mine, :opened, :flaged
+
+  def self.grid_with_mine(width: 9, height: 9, mine_count: 10)
+    Array.new(width * height) { Cell.new }.tap do |cells|
+      cells.sample(mine_count).each(&:plant_mine)
+    end.each_slice(width).to_a
+  end
 
   def initialize
     @mine = false

--- a/test/board_test.rb
+++ b/test/board_test.rb
@@ -26,6 +26,10 @@ class BoardTest < Minitest::Test
     refute cell(x:, y:).opened?
   end
 
+  def assert_cell_neighbors_mine_count(expect, x:, y:)
+    assert expect, cell(x:, y:).neighbors_mine_count
+  end
+
   def test_デフォルトのBoard
     b = Board.new
 
@@ -85,15 +89,15 @@ class BoardTest < Minitest::Test
     Board.new(@grid)
     assert(@grid.flatten.none? { it.neighbors_mine_count.nil? })
 
-    assert_equal 8, cell(x:  1, y: 1).neighbors_mine_count
-    assert_equal 7, cell(x:  3, y: 1).neighbors_mine_count
-    assert_equal 6, cell(x:  5, y: 1).neighbors_mine_count
-    assert_equal 5, cell(x:  7, y: 1).neighbors_mine_count
-    assert_equal 4, cell(x:  9, y: 1).neighbors_mine_count
-    assert_equal 3, cell(x: 11, y: 1).neighbors_mine_count
-    assert_equal 2, cell(x: 13, y: 1).neighbors_mine_count
-    assert_equal 1, cell(x: 15, y: 1).neighbors_mine_count
-    assert_equal 0, cell(x: 17, y: 1).neighbors_mine_count
+    assert_cell_neighbors_mine_count 8, x:  1, y: 1
+    assert_cell_neighbors_mine_count 7, x:  3, y: 1
+    assert_cell_neighbors_mine_count 6, x:  5, y: 1
+    assert_cell_neighbors_mine_count 5, x:  7, y: 1
+    assert_cell_neighbors_mine_count 4, x:  9, y: 1
+    assert_cell_neighbors_mine_count 3, x: 11, y: 1
+    assert_cell_neighbors_mine_count 2, x: 13, y: 1
+    assert_cell_neighbors_mine_count 1, x: 15, y: 1
+    assert_cell_neighbors_mine_count 0, x: 17, y: 1
   end
 
   def test_openメソッドで何もないCellを開く

--- a/test/board_test.rb
+++ b/test/board_test.rb
@@ -18,6 +18,14 @@ class BoardTest < Minitest::Test
     @grid.dig(y, x)
   end
 
+  def assert_cell_opened(x:, y:)
+    assert cell(x:, y:).opened?
+  end
+
+  def assert_cell_closed(x:, y:)
+    refute cell(x:, y:).opened?
+  end
+
   def test_デフォルトのBoard
     b = Board.new
 
@@ -92,7 +100,7 @@ class BoardTest < Minitest::Test
     b = Board.new(grid_with_map('-'))
 
     b.open(x: 0, y: 0)
-    assert cell(x: 0, y: 0).opened?
+    assert_cell_opened(x: 0, y: 0)
   end
 
   def test_openメソッドでmineが埋まっているCellを開く
@@ -105,14 +113,14 @@ class BoardTest < Minitest::Test
     b = Board.new(grid_with_map('-'))
 
     b.open(x: 1, y: 1)
-    refute cell(x: 0, y: 0).opened?
+    assert_cell_closed(x: 0, y: 0)
   end
 
   def test_openメソッドで旗が立っている所は開けない
     b = Board.new(grid_with_map('-'))
 
     b.flag(x: 0, y: 0)
-    refute cell(x: 0, y: 0).opened?
+    assert_cell_closed(x: 0, y: 0)
   end
 
   def test_openメソッドでCellを開いたところが0だったら回りを連鎖的に開く
@@ -124,25 +132,25 @@ class BoardTest < Minitest::Test
     MAP
 
     b.open(x: 3, y: 2)
-    refute cell(x: 0, y: 0).opened?
-    refute cell(x: 1, y: 0).opened?
-    assert cell(x: 2, y: 0).opened?
-    assert cell(x: 3, y: 0).opened?
+    assert_cell_closed(x: 0, y: 0)
+    assert_cell_closed(x: 1, y: 0)
+    assert_cell_opened(x: 2, y: 0)
+    assert_cell_opened(x: 3, y: 0)
 
-    refute cell(x: 0, y: 1).opened?
-    refute cell(x: 1, y: 1).opened?
-    assert cell(x: 2, y: 1).opened?
-    assert cell(x: 3, y: 1).opened?
+    assert_cell_closed(x: 0, y: 1)
+    assert_cell_closed(x: 1, y: 1)
+    assert_cell_opened(x: 2, y: 1)
+    assert_cell_opened(x: 3, y: 1)
 
-    assert cell(x: 0, y: 2).opened?
-    assert cell(x: 1, y: 2).opened?
-    assert cell(x: 2, y: 2).opened?
-    assert cell(x: 3, y: 2).opened?
+    assert_cell_opened(x: 0, y: 2)
+    assert_cell_opened(x: 1, y: 2)
+    assert_cell_opened(x: 2, y: 2)
+    assert_cell_opened(x: 3, y: 2)
 
-    assert cell(x: 0, y: 3).opened?
-    assert cell(x: 1, y: 3).opened?
-    assert cell(x: 2, y: 3).opened?
-    assert cell(x: 3, y: 3).opened?
+    assert_cell_opened(x: 0, y: 3)
+    assert_cell_opened(x: 1, y: 3)
+    assert_cell_opened(x: 2, y: 3)
+    assert_cell_opened(x: 3, y: 3)
   end
 
   def test_openメソッドでchordingして開いたら成功した
@@ -156,31 +164,31 @@ class BoardTest < Minitest::Test
     b.flag(x: 1, y: 1)
     b.open(x: 2, y: 2)
 
-    refute cell(x: 1, y: 1).opened?
-    refute cell(x: 2, y: 1).opened?
-    refute cell(x: 3, y: 1).opened?
+    assert_cell_closed(x: 1, y: 1)
+    assert_cell_closed(x: 2, y: 1)
+    assert_cell_closed(x: 3, y: 1)
 
-    refute cell(x: 1, y: 2).opened?
-    assert cell(x: 2, y: 2).opened?
-    refute cell(x: 3, y: 2).opened?
+    assert_cell_closed(x: 1, y: 2)
+    assert_cell_opened(x: 2, y: 2)
+    assert_cell_closed(x: 3, y: 2)
 
-    refute cell(x: 1, y: 3).opened?
-    refute cell(x: 2, y: 3).opened?
-    refute cell(x: 3, y: 3).opened?
+    assert_cell_closed(x: 1, y: 3)
+    assert_cell_closed(x: 2, y: 3)
+    assert_cell_closed(x: 3, y: 3)
 
     b.open(x: 2, y: 2)
 
-    refute cell(x: 1, y: 1).opened?
-    assert cell(x: 2, y: 1).opened?
-    assert cell(x: 3, y: 1).opened?
+    assert_cell_closed(x: 1, y: 1)
+    assert_cell_opened(x: 2, y: 1)
+    assert_cell_opened(x: 3, y: 1)
 
-    assert cell(x: 1, y: 2).opened?
-    assert cell(x: 2, y: 2).opened?
-    assert cell(x: 3, y: 2).opened?
+    assert_cell_opened(x: 1, y: 2)
+    assert_cell_opened(x: 2, y: 2)
+    assert_cell_opened(x: 3, y: 2)
 
-    assert cell(x: 1, y: 3).opened?
-    assert cell(x: 2, y: 3).opened?
-    assert cell(x: 3, y: 3).opened?
+    assert_cell_opened(x: 1, y: 3)
+    assert_cell_opened(x: 2, y: 3)
+    assert_cell_opened(x: 3, y: 3)
   end
 
   def test_openメソッドでchordingする時、旗が立ってないと発動しない
@@ -193,31 +201,31 @@ class BoardTest < Minitest::Test
 
     b.open(x: 2, y: 2)
 
-    refute cell(x: 1, y: 1).opened?
-    refute cell(x: 2, y: 1).opened?
-    refute cell(x: 3, y: 1).opened?
+    assert_cell_closed(x: 1, y: 1)
+    assert_cell_closed(x: 2, y: 1)
+    assert_cell_closed(x: 3, y: 1)
 
-    refute cell(x: 1, y: 2).opened?
-    assert cell(x: 2, y: 2).opened?
-    refute cell(x: 3, y: 2).opened?
+    assert_cell_closed(x: 1, y: 2)
+    assert_cell_opened(x: 2, y: 2)
+    assert_cell_closed(x: 3, y: 2)
 
-    refute cell(x: 1, y: 3).opened?
-    refute cell(x: 2, y: 3).opened?
-    refute cell(x: 3, y: 3).opened?
+    assert_cell_closed(x: 1, y: 3)
+    assert_cell_closed(x: 2, y: 3)
+    assert_cell_closed(x: 3, y: 3)
 
     b.open(x: 2, y: 2)
 
-    refute cell(x: 1, y: 1).opened?
-    refute cell(x: 2, y: 1).opened?
-    refute cell(x: 3, y: 1).opened?
+    assert_cell_closed(x: 1, y: 1)
+    assert_cell_closed(x: 2, y: 1)
+    assert_cell_closed(x: 3, y: 1)
 
-    refute cell(x: 1, y: 2).opened?
-    assert cell(x: 2, y: 2).opened?
-    refute cell(x: 3, y: 2).opened?
+    assert_cell_closed(x: 1, y: 2)
+    assert_cell_opened(x: 2, y: 2)
+    assert_cell_closed(x: 3, y: 2)
 
-    refute cell(x: 1, y: 3).opened?
-    refute cell(x: 2, y: 3).opened?
-    refute cell(x: 3, y: 3).opened?
+    assert_cell_closed(x: 1, y: 3)
+    assert_cell_closed(x: 2, y: 3)
+    assert_cell_closed(x: 3, y: 3)
   end
 
   def test_openメソッドでchordingする時、旗を立て間違えていると失敗
@@ -231,17 +239,17 @@ class BoardTest < Minitest::Test
     b.open(x: 2, y: 2)
     b.flag(x: 2, y: 1)
 
-    refute cell(x: 1, y: 1).opened?
-    refute cell(x: 2, y: 1).opened?
-    refute cell(x: 3, y: 1).opened?
+    assert_cell_closed(x: 1, y: 1)
+    assert_cell_closed(x: 2, y: 1)
+    assert_cell_closed(x: 3, y: 1)
 
-    refute cell(x: 1, y: 2).opened?
-    assert cell(x: 2, y: 2).opened?
-    refute cell(x: 3, y: 2).opened?
+    assert_cell_closed(x: 1, y: 2)
+    assert_cell_opened(x: 2, y: 2)
+    assert_cell_closed(x: 3, y: 2)
 
-    refute cell(x: 1, y: 3).opened?
-    refute cell(x: 2, y: 3).opened?
-    refute cell(x: 3, y: 3).opened?
+    assert_cell_closed(x: 1, y: 3)
+    assert_cell_closed(x: 2, y: 3)
+    assert_cell_closed(x: 3, y: 3)
 
     assert_raises(Board::GameOver) { b.open(x: 2, y: 2) }
   end
@@ -249,15 +257,15 @@ class BoardTest < Minitest::Test
   def test_flagメソッドで旗を立てたり取ったりする
     b = Board.new(grid_with_map('-'))
 
-    refute cell(x: 0, y: 0).opened?
+    assert_cell_closed(x: 0, y: 0)
     refute cell(x: 0, y: 0).flaged?
 
     b.flag(x: 0, y: 0)
-    refute cell(x: 0, y: 0).opened?
+    assert_cell_closed(x: 0, y: 0)
     assert cell(x: 0, y: 0).flaged?
 
     b.flag(x: 0, y: 0)
-    refute cell(x: 0, y: 0).opened?
+    assert_cell_closed(x: 0, y: 0)
     refute cell(x: 0, y: 0).flaged?
   end
 

--- a/test/board_test.rb
+++ b/test/board_test.rb
@@ -321,4 +321,13 @@ class BoardTest < Minitest::Test
       ---+------------
     TEXT
   end
+
+  def test_to_s
+    b = Board.new(Array.new(12) { DummyCell.new }.each_slice(4).to_a)
+    assert_equal <<-TEXT.chomp, b.to_s
+  0|CCCC
+  1|CCCC
+  2|CCCC
+    TEXT
+  end
 end

--- a/test/board_test.rb
+++ b/test/board_test.rb
@@ -145,6 +145,107 @@ class BoardTest < Minitest::Test
     assert cell(x: 3, y: 3).opened?
   end
 
+  def test_openメソッドでchordingして開いたら成功した
+    b = Board.new(grid_with_map(<<~MAP))
+      ----
+      -x--
+      --1-
+      ----
+    MAP
+
+    b.flag(x: 1, y: 1)
+    b.open(x: 2, y: 2)
+
+    refute cell(x: 1, y: 1).opened?
+    refute cell(x: 2, y: 1).opened?
+    refute cell(x: 3, y: 1).opened?
+
+    refute cell(x: 1, y: 2).opened?
+    assert cell(x: 2, y: 2).opened?
+    refute cell(x: 3, y: 2).opened?
+
+    refute cell(x: 1, y: 3).opened?
+    refute cell(x: 2, y: 3).opened?
+    refute cell(x: 3, y: 3).opened?
+
+    b.open(x: 2, y: 2)
+
+    refute cell(x: 1, y: 1).opened?
+    assert cell(x: 2, y: 1).opened?
+    assert cell(x: 3, y: 1).opened?
+
+    assert cell(x: 1, y: 2).opened?
+    assert cell(x: 2, y: 2).opened?
+    assert cell(x: 3, y: 2).opened?
+
+    assert cell(x: 1, y: 3).opened?
+    assert cell(x: 2, y: 3).opened?
+    assert cell(x: 3, y: 3).opened?
+  end
+
+  def test_openメソッドでchordingする時、旗が立ってないと発動しない
+    b = Board.new(grid_with_map(<<~MAP))
+      ----
+      -x--
+      --1-
+      ----
+    MAP
+
+    b.open(x: 2, y: 2)
+
+    refute cell(x: 1, y: 1).opened?
+    refute cell(x: 2, y: 1).opened?
+    refute cell(x: 3, y: 1).opened?
+
+    refute cell(x: 1, y: 2).opened?
+    assert cell(x: 2, y: 2).opened?
+    refute cell(x: 3, y: 2).opened?
+
+    refute cell(x: 1, y: 3).opened?
+    refute cell(x: 2, y: 3).opened?
+    refute cell(x: 3, y: 3).opened?
+
+    b.open(x: 2, y: 2)
+
+    refute cell(x: 1, y: 1).opened?
+    refute cell(x: 2, y: 1).opened?
+    refute cell(x: 3, y: 1).opened?
+
+    refute cell(x: 1, y: 2).opened?
+    assert cell(x: 2, y: 2).opened?
+    refute cell(x: 3, y: 2).opened?
+
+    refute cell(x: 1, y: 3).opened?
+    refute cell(x: 2, y: 3).opened?
+    refute cell(x: 3, y: 3).opened?
+  end
+
+  def test_openメソッドでchordingする時、旗を立て間違えていると失敗
+    b = Board.new(grid_with_map(<<~MAP))
+      ----
+      -xF-
+      --1-
+      ----
+    MAP
+
+    b.open(x: 2, y: 2)
+    b.flag(x: 2, y: 1)
+
+    refute cell(x: 1, y: 1).opened?
+    refute cell(x: 2, y: 1).opened?
+    refute cell(x: 3, y: 1).opened?
+
+    refute cell(x: 1, y: 2).opened?
+    assert cell(x: 2, y: 2).opened?
+    refute cell(x: 3, y: 2).opened?
+
+    refute cell(x: 1, y: 3).opened?
+    refute cell(x: 2, y: 3).opened?
+    refute cell(x: 3, y: 3).opened?
+
+    assert_raises(Board::GameOver) { b.open(x: 2, y: 2) }
+  end
+
   def test_flagメソッドで旗を立てたり取ったりする
     b = Board.new(grid_with_map('-'))
 

--- a/test/board_test.rb
+++ b/test/board_test.rb
@@ -301,4 +301,24 @@ class BoardTest < Minitest::Test
 
     assert b.finished?
   end
+
+  class DummyCell < Cell
+    def to_s
+      'C'
+    end
+  end
+
+  def test_show
+    b = Board.new(Array.new(12) { DummyCell.new }.each_slice(4).to_a)
+    stdout, = capture_io { b.show }
+    assert_equal <<~TEXT, stdout
+      \e[2J\e[1;1H \\x|
+      y \\| 0  1  2  3
+      ---+------------
+        0|CCCC
+        1|CCCC
+        2|CCCC
+      ---+------------
+    TEXT
+  end
 end

--- a/test/board_test.rb
+++ b/test/board_test.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require_relative '../minesweeper'
+
+class BoardTest < Minitest::Test
+  def setup
+    $stdout = File.open('/dev/null', 'w')
+  end
+
+  def teardown
+    $stdout.close
+    $stdout = STDOUT
+  end
+
+  def grid_with_map(map)
+    width = map.lines.first.chomp.length
+    map = map.delete("\n")
+
+    cells = Array.new(map.size) { Cell.new }
+    map.each_char.with_index { |c, i| c == 'x' && cells[i].plant_mine }
+
+    cells.each_slice(width).to_a
+  end
+
+  def test_デフォルトのBoard
+    b = Board.new
+    assert_equal 9 + 4, b.show
+    refute b.finished?
+
+    assert_raises(Board::GameOver) do
+      9.times do |x|
+        9.times do |y|
+          b.open(x:, y:)
+        end
+      end
+    end
+  end
+
+  def test_test用のmine位置を指定したBoard
+    b = Board.new(grid_with_map(<<~MAP))
+      --------
+      --x-----
+      -----x--
+      --------
+    MAP
+
+    assert_equal 4 + 4, b.show
+    refute b.finished?
+
+    8.times do |x|
+      4.times do |y|
+        next if [x, y] in [2, 1] | [5, 2]
+
+        b.open(x:, y:)
+      end
+    end
+
+    assert b.finished?
+  end
+end

--- a/test/board_test.rb
+++ b/test/board_test.rb
@@ -280,4 +280,25 @@ class BoardTest < Minitest::Test
     refute cell(x: 10, y: 10)
     refute cell(x: 0, y: 0).flaged?
   end
+
+  def test_mineでないすべてのCellがopenされていればゲーム終了
+    b = Board.new(grid_with_map('-x-'))
+
+    refute b.finished?
+    b.open(x: 0, y: 0)
+    b.flag(x: 1, y: 0)
+    b.open(x: 2, y: 0)
+
+    assert b.finished?
+  end
+
+  def test_ゲーム終了の条件に旗は関係ない
+    b = Board.new(grid_with_map('-x-'))
+
+    refute b.finished?
+    b.open(x: 0, y: 0)
+    b.open(x: 2, y: 0)
+
+    assert b.finished?
+  end
 end

--- a/test/board_test.rb
+++ b/test/board_test.rb
@@ -65,6 +65,29 @@ class BoardTest < Minitest::Test
     assert b.finished?
   end
 
+  def test_BoardにCellを渡すと近隣のmine数がセットされる
+    grid_with_map(<<~MAP)
+      xxxx--x------------
+      x8x7x6x5-4x3-2-1-0-
+      xxxxxxxxxxxx-xx----
+    MAP
+
+    assert(@grid.flatten.all? { it.neighbors_mine_count.nil? })
+
+    Board.new(@grid)
+    assert(@grid.flatten.none? { it.neighbors_mine_count.nil? })
+
+    assert_equal 8, cell(x:  1, y: 1).neighbors_mine_count
+    assert_equal 7, cell(x:  3, y: 1).neighbors_mine_count
+    assert_equal 6, cell(x:  5, y: 1).neighbors_mine_count
+    assert_equal 5, cell(x:  7, y: 1).neighbors_mine_count
+    assert_equal 4, cell(x:  9, y: 1).neighbors_mine_count
+    assert_equal 3, cell(x: 11, y: 1).neighbors_mine_count
+    assert_equal 2, cell(x: 13, y: 1).neighbors_mine_count
+    assert_equal 1, cell(x: 15, y: 1).neighbors_mine_count
+    assert_equal 0, cell(x: 17, y: 1).neighbors_mine_count
+  end
+
   def test_flagメソッドで旗を立てたり取ったりする
     b = Board.new(grid_with_map('-'))
 

--- a/test/board_test.rb
+++ b/test/board_test.rb
@@ -4,15 +4,6 @@ require 'minitest/autorun'
 require_relative '../minesweeper'
 
 class BoardTest < Minitest::Test
-  def setup
-    $stdout = File.open('/dev/null', 'w')
-  end
-
-  def teardown
-    $stdout.close
-    $stdout = STDOUT
-  end
-
   def grid_with_map(map)
     width = map.lines.first.chomp.length
     map = map.delete("\n")
@@ -29,8 +20,11 @@ class BoardTest < Minitest::Test
 
   def test_デフォルトのBoard
     b = Board.new
-    assert_equal 9 + 4, b.show
-    refute b.finished?
+
+    capture_io do
+      assert_equal 9 + 4, b.show
+      refute b.finished?
+    end
 
     assert_raises(Board::GameOver) do
       9.times do |x|
@@ -49,8 +43,10 @@ class BoardTest < Minitest::Test
       --------
     MAP
 
-    assert_equal 4 + 4, b.show
-    refute b.finished?
+    capture_io do
+      assert_equal 4 + 4, b.show
+      refute b.finished?
+    end
 
     b.flag(x: 2, y: 1)
     b.flag(x: 5, y: 2)

--- a/test/board_test.rb
+++ b/test/board_test.rb
@@ -88,6 +88,63 @@ class BoardTest < Minitest::Test
     assert_equal 0, cell(x: 17, y: 1).neighbors_mine_count
   end
 
+  def test_openメソッドで何もないCellを開く
+    b = Board.new(grid_with_map('-'))
+
+    b.open(x: 0, y: 0)
+    assert cell(x: 0, y: 0).opened?
+  end
+
+  def test_openメソッドでmineが埋まっているCellを開く
+    b = Board.new(grid_with_map('x'))
+
+    assert_raises(Board::GameOver) { b.open(x: 0, y: 0) }
+  end
+
+  def test_openメソッドでCellがない所を開いても何も起きない
+    b = Board.new(grid_with_map('-'))
+
+    b.open(x: 1, y: 1)
+    refute cell(x: 0, y: 0).opened?
+  end
+
+  def test_openメソッドで旗が立っている所は開けない
+    b = Board.new(grid_with_map('-'))
+
+    b.flag(x: 0, y: 0)
+    refute cell(x: 0, y: 0).opened?
+  end
+
+  def test_openメソッドでCellを開いたところが0だったら回りを連鎖的に開く
+    b = Board.new(grid_with_map(<<~MAP))
+      ??1-
+      ?x1-
+      111-
+      ----
+    MAP
+
+    b.open(x: 3, y: 2)
+    refute cell(x: 0, y: 0).opened?
+    refute cell(x: 1, y: 0).opened?
+    assert cell(x: 2, y: 0).opened?
+    assert cell(x: 3, y: 0).opened?
+
+    refute cell(x: 0, y: 1).opened?
+    refute cell(x: 1, y: 1).opened?
+    assert cell(x: 2, y: 1).opened?
+    assert cell(x: 3, y: 1).opened?
+
+    assert cell(x: 0, y: 2).opened?
+    assert cell(x: 1, y: 2).opened?
+    assert cell(x: 2, y: 2).opened?
+    assert cell(x: 3, y: 2).opened?
+
+    assert cell(x: 0, y: 3).opened?
+    assert cell(x: 1, y: 3).opened?
+    assert cell(x: 2, y: 3).opened?
+    assert cell(x: 3, y: 3).opened?
+  end
+
   def test_flagメソッドで旗を立てたり取ったりする
     b = Board.new(grid_with_map('-'))
 

--- a/test/board_test.rb
+++ b/test/board_test.rb
@@ -20,7 +20,11 @@ class BoardTest < Minitest::Test
     cells = Array.new(map.size) { Cell.new }
     map.each_char.with_index { |c, i| c == 'x' && cells[i].plant_mine }
 
-    cells.each_slice(width).to_a
+    @grid = cells.each_slice(width).to_a
+  end
+
+  def cell(x:, y:)
+    @grid.dig(y, x)
   end
 
   def test_デフォルトのBoard
@@ -48,6 +52,12 @@ class BoardTest < Minitest::Test
     assert_equal 4 + 4, b.show
     refute b.finished?
 
+    b.flag(x: 2, y: 1)
+    b.flag(x: 5, y: 2)
+
+    assert cell(x: 2, y: 1).flaged?
+    assert cell(x: 5, y: 2).flaged?
+
     8.times do |x|
       4.times do |y|
         next if [x, y] in [2, 1] | [5, 2]
@@ -57,5 +67,28 @@ class BoardTest < Minitest::Test
     end
 
     assert b.finished?
+  end
+
+  def test_flagメソッドで旗を立てたり取ったりする
+    b = Board.new(grid_with_map('-'))
+
+    refute cell(x: 0, y: 0).opened?
+    refute cell(x: 0, y: 0).flaged?
+
+    b.flag(x: 0, y: 0)
+    refute cell(x: 0, y: 0).opened?
+    assert cell(x: 0, y: 0).flaged?
+
+    b.flag(x: 0, y: 0)
+    refute cell(x: 0, y: 0).opened?
+    refute cell(x: 0, y: 0).flaged?
+  end
+
+  def test_flagメソッドで枠外を指定
+    b = Board.new(grid_with_map('-'))
+
+    b.flag(x: 10, y: 10)
+    refute cell(x: 10, y: 10)
+    refute cell(x: 0, y: 0).flaged?
   end
 end

--- a/test/cell_test.rb
+++ b/test/cell_test.rb
@@ -112,4 +112,12 @@ class CellTest < Minitest::Test
     cell.neighbors_mine_count = 8
     assert_equal "#{Cell::NUMBER_COLOR[8]}#{Cell::BOLD}８ #{Cell::COLOR_RESET}", cell.to_s
   end
+
+  def test_9x9でmineが10個のCell配列を生成する
+    cells = Cell.grid_with_mine.flatten
+
+    assert(cells.all? { it.instance_of?(Cell) })
+    assert_equal 9 * 9, cells.size
+    assert_equal 10, cells.count(&:mine?)
+  end
 end


### PR DESCRIPTION
#2 でまぁまぁいい線まで行けて、ヘルパーメソッドの実装が気持ち悪いという点が問題になった。

という事で、Board.new した後にgridを置き換えるのではなく、先に外でgridを生成してBoard.newに渡す感じに変更した。
書き味も悪くない。これでいい気がする。

ヘルパーの実装もBoard#initializeと独立してる。ただCellを作ってgrid化(二次元配列に)してるだけだし。

本体コードの方では、CellGeneratorというクラスを作ろうかとも思ったが、結局クラスメソッド1つだけって事になりそうだし、
だったらCellがCellインスタンスを作るのは変ではないので、Cellのクラスメソッドでいいじゃんと考えた。

その結果 Cell.grid_with_mine として実装してみた。

とりあえず、よさそうだったので、Board#open以外のテストも書いてみた。
